### PR TITLE
Fix JawsDB variable

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -16,6 +16,6 @@ module.exports = {
   },
   production: {
     dialect: "mysql",
-    use_env_variable: JAWSDB_URL
+    use_env_variable: process.env.JAWSDB_URL
   }
 };


### PR DESCRIPTION
I forgot the `process.env` prefix.